### PR TITLE
 fix "E: The method driver /usr/lib/apt/methods/https could not be found."  error

### DIFF
--- a/code/5/jenkins/Dockerfile
+++ b/code/5/jenkins/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:14.04
 MAINTAINER james@example.com
 ENV REFRESHED_AT 2014-06-01
 
-RUN apt-get update -qq && apt-get install -qqy curl
+RUN apt-get update -qq && apt-get install -qqy curl apt-transport-https
 RUN curl https://get.docker.com/gpg | apt-key add -
 RUN echo deb http://get.docker.com/ubuntu docker main > /etc/apt/sources.list.d/docker.list
 RUN apt-get update -qq && apt-get install -qqy iptables ca-certificates lxc openjdk-6-jdk git-core lxc-docker


### PR DESCRIPTION
add insatll apt-transport-https to fix "E: The method driver /usr/lib/apt/methods/https could not be found."  error